### PR TITLE
chore: exclude alpm related from build by default

### DIFF
--- a/cmd/list_archlinux.go
+++ b/cmd/list_archlinux.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 /*
 Copyright © 2022 maxgio92 <me@maxgio.it>
 

--- a/pkg/distro/archlinux/archlinux.go
+++ b/pkg/distro/archlinux/archlinux.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 /*
 Copyright © 2022 maxgio92 <me@maxgio.it>
 

--- a/pkg/distro/archlinux/config.go
+++ b/pkg/distro/archlinux/config.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 /*
 Copyright © 2022 maxgio92 <me@maxgio.it>
 

--- a/pkg/distro/archlinux/constants.go
+++ b/pkg/distro/archlinux/constants.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 /*
 Copyright © 2022 maxgio92 <me@maxgio.it>
 

--- a/pkg/packages/alpm/alpm.go
+++ b/pkg/packages/alpm/alpm.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 package alpm
 
 import (

--- a/pkg/packages/alpm/errors.go
+++ b/pkg/packages/alpm/errors.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 package alpm
 
 import (

--- a/pkg/packages/alpm/search.go
+++ b/pkg/packages/alpm/search.go
@@ -1,3 +1,5 @@
+//go:build archlinux
+
 package alpm
 
 import (


### PR DESCRIPTION
As libalpm is needed on the build host by default the ALPM and distros that use it like Arch Linux should be excluded by default from the build.

This PR excludes by default with Go build flags ALPM and Arch Linux packages and commands.